### PR TITLE
버스 막차 계산 로직 관련 오류 수정, LiveData 중복 observe 문제 처리

### DIFF
--- a/data/src/main/java/com/stop/data/remote/model/route/gyeonggi/GyeonggiBusLastTimeResponse.kt
+++ b/data/src/main/java/com/stop/data/remote/model/route/gyeonggi/GyeonggiBusLastTimeResponse.kt
@@ -8,5 +8,5 @@ import com.tickaroo.tikxml.annotation.Xml
 internal data class GyeonggiBusLastTimeResponse(
     @Path("msgBody")
     @Element(name = "busRouteInfoItem")
-    val lastTimes: List<GyeonggiBusLastTime>
+    val lastTimes: List<GyeonggiBusLastTime>?
 )

--- a/data/src/main/java/com/stop/data/remote/source/route/RouteRemoteDataSource.kt
+++ b/data/src/main/java/com/stop/data/remote/source/route/RouteRemoteDataSource.kt
@@ -29,10 +29,10 @@ internal interface RouteRemoteDataSource {
 
     suspend fun getSeoulBusStationArsId(stationName: String): List<BusStationInfo>
     suspend fun getSeoulBusRoute(stationId: String): List<BusRouteInfo>
-    suspend fun getSeoulBusLastTime(stationId: String, lineId: String): List<LastTimeInfo>
+    suspend fun getSeoulBusLastTime(stationId: String, lineId: String): List<LastTimeInfo>?
 
     suspend fun getGyeonggiBusStationId(stationName: String): List<GyeonggiBusStation>
     suspend fun getGyeonggiBusRoute(stationId: String): List<GyeonggiBusRoute>
-    suspend fun getGyeonggiBusLastTime(lineId: String): List<GyeonggiBusLastTime>
+    suspend fun getGyeonggiBusLastTime(lineId: String): List<GyeonggiBusLastTime>?
     suspend fun getGyeonggiBusRouteStations(lineId: String): List<GyeonggiBusStation>
 }

--- a/data/src/main/java/com/stop/data/remote/source/route/RouteRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/stop/data/remote/source/route/RouteRemoteDataSourceImpl.kt
@@ -140,7 +140,7 @@ internal class RouteRemoteDataSourceImpl @Inject constructor(
     override suspend fun getSeoulBusLastTime(
         stationId: String,
         lineId: String
-    ): List<LastTimeInfo> {
+    ): List<LastTimeInfo>? {
         with(wsBusApiService.getBusLastTime(stationId, lineId)) {
             return when (this) {
                 is NetworkResult.Success -> this.data.lastTimeMsgBody.lastTimes
@@ -173,10 +173,10 @@ internal class RouteRemoteDataSourceImpl @Inject constructor(
         }
     }
 
-    override suspend fun getGyeonggiBusLastTime(lineId: String): List<GyeonggiBusLastTime> {
+    override suspend fun getGyeonggiBusLastTime(lineId: String): List<GyeonggiBusLastTime>? {
         with(apisDataService.getBusLastTime(lineId)) {
             return when (this) {
-                is NetworkResult.Success -> this.data.lastTimes.map { it.toDomain() }
+                is NetworkResult.Success -> this.data.lastTimes?.map { it.toDomain() }
                 is NetworkResult.Failure -> throw IllegalArgumentException(this.message)
                 is NetworkResult.NetworkError -> throw this.exception
                 is NetworkResult.Unexpected -> throw this.exception

--- a/data/src/main/java/com/stop/data/repository/RouteRepositoryImpl.kt
+++ b/data/src/main/java/com/stop/data/repository/RouteRepositoryImpl.kt
@@ -76,7 +76,7 @@ internal class RouteRepositoryImpl @Inject constructor(
         return remoteDataSource.getSeoulBusRoute(stationId)
     }
 
-    override suspend fun getSeoulBusLastTime(stationId: String, lineId: String): List<LastTimeInfo> {
+    override suspend fun getSeoulBusLastTime(stationId: String, lineId: String): List<LastTimeInfo>? {
         return remoteDataSource.getSeoulBusLastTime(stationId, lineId)
     }
 
@@ -88,7 +88,7 @@ internal class RouteRepositoryImpl @Inject constructor(
         return remoteDataSource.getGyeonggiBusRoute(stationId)
     }
 
-    override suspend fun getGyeonggiBusLastTime(lineId: String): List<GyeonggiBusLastTime> {
+    override suspend fun getGyeonggiBusLastTime(lineId: String): List<GyeonggiBusLastTime>? {
         return remoteDataSource.getGyeonggiBusLastTime(lineId)
     }
 

--- a/domain/src/main/java/com/stop/domain/model/route/seoul/bus/LastTimeMsgBody.kt
+++ b/domain/src/main/java/com/stop/domain/model/route/seoul/bus/LastTimeMsgBody.kt
@@ -6,5 +6,5 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class LastTimeMsgBody(
     @Json(name = "itemList")
-    val lastTimes: List<LastTimeInfo>
+    val lastTimes: List<LastTimeInfo>?
 )

--- a/domain/src/main/java/com/stop/domain/repository/RouteRepository.kt
+++ b/domain/src/main/java/com/stop/domain/repository/RouteRepository.kt
@@ -30,7 +30,7 @@ interface RouteRepository {
 
     suspend fun getSeoulBusStationArsId(stationName: String): List<BusStationInfo>
     suspend fun getSeoulBusRoute(stationId: String): List<BusRouteInfo>
-    suspend fun getSeoulBusLastTime(stationId: String, lineId: String): List<LastTimeInfo>
+    suspend fun getSeoulBusLastTime(stationId: String, lineId: String): List<LastTimeInfo>?
     suspend fun getSubwayRoute(
         routeRequest: RouteRequest,
         subwayLine: String,
@@ -40,6 +40,6 @@ interface RouteRepository {
 
     suspend fun getGyeonggiBusStationId(stationName: String): List<GyeonggiBusStation>
     suspend fun getGyeonggiBusRoute(stationId: String): List<GyeonggiBusRoute>
-    suspend fun getGyeonggiBusLastTime(lineId: String): List<GyeonggiBusLastTime>
+    suspend fun getGyeonggiBusLastTime(lineId: String): List<GyeonggiBusLastTime>?
     suspend fun getGyeonggiBusRouteStations(lineId: String): List<GyeonggiBusStation>
 }

--- a/presentation/src/main/java/com/stop/ui/route/RouteFragment.kt
+++ b/presentation/src/main/java/com/stop/ui/route/RouteFragment.kt
@@ -82,7 +82,9 @@ class RouteFragment : Fragment() {
         }
 
         viewModel.lastTimeResponse.observe(viewLifecycleOwner) {
-            binding.root.findNavController().navigate(R.id.action_routeFragment_to_routeDetailFragment)
+            it.getContentIfNotHandled()?.let {
+                binding.root.findNavController().navigate(R.id.action_routeFragment_to_routeDetailFragment)
+            }
         }
     }
 

--- a/presentation/src/main/java/com/stop/ui/route/RouteViewModel.kt
+++ b/presentation/src/main/java/com/stop/ui/route/RouteViewModel.kt
@@ -35,8 +35,8 @@ class RouteViewModel @Inject constructor(
     val routeResponse: LiveData<List<Itinerary>>
         get() = _routeResponse
 
-    private val _lastTimeResponse = MutableLiveData<List<String?>>()
-    val lastTimeResponse: LiveData<List<String?>>
+    private val _lastTimeResponse = MutableLiveData<Event<List<String?>>>()
+    val lastTimeResponse: LiveData<Event<List<String?>>>
         get() = _lastTimeResponse
 
     private val _errorMessage = MutableLiveData<Event<ErrorType>>()
@@ -69,7 +69,7 @@ class RouteViewModel @Inject constructor(
     fun calculateLastTransportTime(itinerary: Itinerary) {
         checkClickedItinerary(itinerary)
         viewModelScope.launch {
-            this@RouteViewModel._lastTimeResponse.value = getLastTransportTimeUseCase(itinerary)
+            this@RouteViewModel._lastTimeResponse.value = Event(getLastTransportTimeUseCase(itinerary))
         }
     }
 
@@ -90,7 +90,7 @@ class RouteViewModel @Inject constructor(
         val lastTimes = _lastTimeResponse.value ?: return "이 함수를 호출한 시점에 막차 데이터가 null인 논리적 오류가 발생했습니다."
 
         return clickedItinerary.routes.mapIndexed { index, route ->
-            "${route.start.name}(${lastTimes[index]})"
+            "${route.start.name}(${lastTimes.peekContent()[index]})"
         }.joinToString(" -> ")
     }
 }

--- a/presentation/src/main/res/navigation/nav_graph.xml
+++ b/presentation/src/main/res/navigation/nav_graph.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph"
-    app:startDestination="@id/alarmSetting">
+    app:startDestination="@id/mapFragment">
 
     <fragment
         android:id="@+id/mapFragment"


### PR DESCRIPTION
## PR Description
- 관련 이슈 : https://github.com/boostcampwm-2022/android10-PlzStop/issues/61
- 관련 문서 : 위 이슈에 오류 해결 및 로직 검증 과정에서 사용한 결과 첨부 예정

## Changes
- 서울 관할 버스를 경기도로, 경기도 관할 버스를 서울로 잘못 판별한 경우 대응 로직 추가
- Fragment 재생성 시 ViewModel에 있는 LiveData 중복 Observe 문제 해결

